### PR TITLE
Changes in the updated version of FLEXDUST

### DIFF
--- a/src/FLEXDUST.f90
+++ b/src/FLEXDUST.f90
@@ -437,8 +437,9 @@ program FLEXDUST
                                     !*****************************
                                     call dustEmmission_Kok14(emission_mass_step(ix,iy), soilFraction(ix,iy), &
                                     lat_out, dx_dy_out, inNestNr(ix,iy),  ix_wind(ix), iy_wind(iy), &
-                                    ix_wind_n(ix,inNestNr(ix,iy)), iy_wind_n(iy,inNestNr(ix,iy)),emission_time, &
-                                    frictVelThres, inClayGrid(ix,iy), clayContent(ix_clay(ix),iy_clay(iy)))
+                                    ix_wind_n(ix,inNestNr(ix,iy)), iy_wind_n(iy,inNestNr(ix,iy)),emission_time, scalingFactor, &
+                                    frictVelThres, inClayGrid(ix,iy), clayContent(ix_clay(ix),iy_clay(iy)), & 
+                                    emission_flux_step(ix,iy), gridarea(ix,iy))
                                 endif
                                 !*****************************
                             endif!emission model with varying threshold

--- a/src/FLEXDUST.f90
+++ b/src/FLEXDUST.f90
@@ -50,7 +50,7 @@ program FLEXDUST
     real,dimension(:,:), allocatable    :: gridarea(:,:)
     real,dimension(:,:), allocatable    :: emission_mass(:,:),emission_flux(:,:), soilMoisture(:,:), cum_emission(:,:)
     real,dimension(:,:), allocatable    :: emission_mass_step(:,:),emission_flux_step(:,:)
-    real,dimension(:,:), allocatable    :: outputField(:,:), erodibility(:,:)
+    real,dimension(:,:), allocatable    :: outputField(:,:), erodibility(:,:), erodibility_total(:,:)
     real,dimension(:,:), allocatable    :: sandMap(:,:), clayMap(:,:)
     real,dimension(:,:,:), allocatable  :: precipitation
     integer,dimension(:,:), allocatable :: inNestNr,  ix_wind_n, iy_wind_n, landcovertype
@@ -139,6 +139,9 @@ program FLEXDUST
     allocate(erodibility(0:nx_lon_out-1,0:ny_lat_out-1), STAT=ALLOC_ERR)
     IF (ALLOC_ERR /= 0) STOP "*** Not enough memory ***"
     
+    allocate(erodibility_total(0:nx_lon_out-1,0:ny_lat_out-1), STAT=ALLOC_ERR)
+    IF (ALLOC_ERR /= 0) STOP "*** Not enough memory ***"
+
     allocate(sandMap(0:nx_lon_out-1,0:ny_lat_out-1), STAT=ALLOC_ERR)
     IF (ALLOC_ERR /= 0) STOP "*** Not enough memory ***"
     
@@ -347,8 +350,36 @@ program FLEXDUST
                     !In first time step only determine erodibility at grid point if switched on
                     !********************************************************
                     if(tot_sec.eq.0 .and. EROSION_TOPO)then
+                        
+                        erodibility_total(ix,iy)=0
+                        
                         !get lower left corner (ix_ll, iy_ll) of erosion area
+                        call getGridPointWind(lat_out-2., lon_out-2,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
                         !get upper right corner (ix_ur, iy_ur) of erosion area
+                        call getGridPointWind(lat_out+2., lon_out+2.,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
+                        !scale erodibility in this area
+                        call getErodibility(erodibility(ix,iy), ix_wind(ix), iy_wind(iy), ix_ll, ix_ur, iy_ll, iy_ur)
+                        
+                        erodibility_total(ix,iy)=erodibility_total(ix,iy)+erodibility(ix,iy)
+                        
+                        !get lower left corner (ix_ll, iy_ll) of erosion area
+                        call getGridPointWind(lat_out-5., lon_out-5,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
+                        !get upper right corner (ix_ur, iy_ur) of erosion area
+                        call getGridPointWind(lat_out+5., lon_out+5.,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
+                        !scale erodibility in this area
+                        call getErodibility(erodibility(ix,iy), ix_wind(ix), iy_wind(iy), ix_ll, ix_ur, iy_ll, iy_ur)
+                        
+                        erodibility_total(ix,iy)=erodibility_total(ix,iy)+erodibility(ix,iy)
+                        
+                        !get lower left corner (ix_ll, iy_ll) of erosion area
+                        call getGridPointWind(lat_out-10., lon_out-10,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
+                        !get upper right corner (ix_ur, iy_ur) of erosion area
+                        call getGridPointWind(lat_out+10., lon_out+10.,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
+                        !scale erodibility in this area
+                        call getErodibility(erodibility(ix,iy), ix_wind(ix), iy_wind(iy), ix_ll, ix_ur, iy_ll, iy_ur)
+                        
+                        erodibility_total(ix,iy)=erodibility_total(ix,iy)+erodibility(ix,iy)
+                        
                         !get lower left corner (ix_ll, iy_ll) of erosion area
                         call getGridPointWind(lat_out-15., lon_out-15,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
                         !get upper right corner (ix_ur, iy_ur) of erosion area
@@ -356,7 +387,11 @@ program FLEXDUST
                         !scale erodibility in this area
                         call getErodibility(erodibility(ix,iy), ix_wind(ix), iy_wind(iy), ix_ll, ix_ur, iy_ll, iy_ur)
                         
-                        soilFraction(ix,iy)=soilFraction(ix,iy)*erodibility(ix,iy)
+                        erodibility_total(ix,iy)=erodibility_total(ix,iy)+erodibility(ix,iy)
+                        
+                        erodibility_total(ix,iy)=erodibility_total(ix,iy)/4
+                        
+                        soilFraction(ix,iy)=soilFraction(ix,iy)*erodibility_total(ix,iy)
 
                         !Store soil fraction grid when finished > now only save in netcdf
                         !if(iy.eq.ny_lat_out-1 .and. ix.eq.nx_lon_out-1)then

--- a/src/FLEXDUST.f90
+++ b/src/FLEXDUST.f90
@@ -354,36 +354,36 @@ program FLEXDUST
                         erodibility_total(ix,iy)=0
                         
                         !get lower left corner (ix_ll, iy_ll) of erosion area
-                        call getGridPointWind(lat_out-2., lon_out-2,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
+                        call getGridPointWind(lat_out-0.6, lon_out-0.6,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
                         !get upper right corner (ix_ur, iy_ur) of erosion area
-                        call getGridPointWind(lat_out+2., lon_out+2.,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
+                        call getGridPointWind(lat_out+0.6, lon_out+0.6,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
                         !scale erodibility in this area
                         call getErodibility(erodibility(ix,iy), ix_wind(ix), iy_wind(iy), ix_ll, ix_ur, iy_ll, iy_ur)
                         
                         erodibility_total(ix,iy)=erodibility_total(ix,iy)+erodibility(ix,iy)
                         
                         !get lower left corner (ix_ll, iy_ll) of erosion area
-                        call getGridPointWind(lat_out-5., lon_out-5,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
+                        call getGridPointWind(lat_out-1.5, lon_out-1.5,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
                         !get upper right corner (ix_ur, iy_ur) of erosion area
-                        call getGridPointWind(lat_out+5., lon_out+5.,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
+                        call getGridPointWind(lat_out+1.5, lon_out+1.5,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
                         !scale erodibility in this area
                         call getErodibility(erodibility(ix,iy), ix_wind(ix), iy_wind(iy), ix_ll, ix_ur, iy_ll, iy_ur)
                         
                         erodibility_total(ix,iy)=erodibility_total(ix,iy)+erodibility(ix,iy)
                         
                         !get lower left corner (ix_ll, iy_ll) of erosion area
-                        call getGridPointWind(lat_out-10., lon_out-10,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
+                        call getGridPointWind(lat_out-3, lon_out-3,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
                         !get upper right corner (ix_ur, iy_ur) of erosion area
-                        call getGridPointWind(lat_out+10., lon_out+10.,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
+                        call getGridPointWind(lat_out+3, lon_out+3,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
                         !scale erodibility in this area
                         call getErodibility(erodibility(ix,iy), ix_wind(ix), iy_wind(iy), ix_ll, ix_ur, iy_ll, iy_ur)
                         
                         erodibility_total(ix,iy)=erodibility_total(ix,iy)+erodibility(ix,iy)
                         
                         !get lower left corner (ix_ll, iy_ll) of erosion area
-                        call getGridPointWind(lat_out-15., lon_out-15,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
+                        call getGridPointWind(lat_out-4.5, lon_out-4.5,dummy_int, ix_ll, iy_ll, dummy_int, dummy_int)
                         !get upper right corner (ix_ur, iy_ur) of erosion area
-                        call getGridPointWind(lat_out+15., lon_out+15.,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
+                        call getGridPointWind(lat_out+4.5, lon_out+4.5,dummy_int, ix_ur, iy_ur,dummy_int,dummy_int)
                         !scale erodibility in this area
                         call getErodibility(erodibility(ix,iy), ix_wind(ix), iy_wind(iy), ix_ll, ix_ur, iy_ll, iy_ur)
                         

--- a/src/calcThreshold_tau.f90
+++ b/src/calcThreshold_tau.f90
@@ -29,7 +29,7 @@ subroutine calcThreshold_tau(frictVelThres, shearStressThres, inClay, clayCont_l
     real :: precipMem(1:40)
     real :: f_d, soilFract, tmp_1, tmp_2, z0s, z0m
     real :: w, w_acc, rho_air, Diam_p, precip
-    real, parameter :: gamma_shao = 2.9e-4, An = 0.111
+    real, parameter :: gamma_shao = 2.9e-4, An = 0.05  !An = 0.111
     real, parameter :: rho_p = 2500
     logical :: inClay, inErC
     !********************************************************************************* 

--- a/src/dustEmission_Kok14.f90
+++ b/src/dustEmission_Kok14.f90
@@ -18,15 +18,17 @@
 ! along with FLEXDUST.  If not, see <http://www.gnu.org/licenses/>.   *
 !**********************************************************************
 
-subroutine dustEmmission_Kok14(em, soilF, lat,dxdy_degr, inNestNr, ix_wind, iy_wind, ix_wind_n, iy_wind_n,&
-                                time_int,mobilisationThreshold,inClay, f_clay_tmp)
+subroutine dustEmmission_Kok14(em_mass, soilF, lat,dxdy_degr, inNestNr, ix_wind, iy_wind, ix_wind_n, iy_wind_n, &
+                                time_int, scalingFactor, mobilisationThreshold,inClay, f_clay_tmp, em_flux, &
+                                gridarea)
 
     use par_mod
     use com_mod
 
     implicit none
 
-    real     :: mfac, em, lat, mass, mobilisationThreshold, dxdy_degr
+    real     :: mfac, em_mass, em_flux, lat, mass, mobilisationThreshold, dxdy_degr
+    real*8   :: scalingFactor
     real     :: soilF
     real     :: u_star_local, rho_air, flux
     integer  :: ix_wind, iy_wind, ix_wind_n, iy_wind_n, time_int, inNestNr
@@ -35,7 +37,7 @@ subroutine dustEmmission_Kok14(em, soilF, lat,dxdy_degr, inNestNr, ix_wind, iy_w
     real, parameter :: C_e=2.0
     real, parameter :: rho_air_0=1.225
     real, parameter :: u_star_st_0=0.16
-    real :: f_clay, f_clay_tmp, C_d, tmp, f_bare, u_star_st, u_star_t
+    real :: f_clay, f_clay_tmp, C_d, tmp, f_bare, u_star_st, u_star_t, gridarea
     logical ::inClay
 
         !Get friction velocity
@@ -65,22 +67,22 @@ subroutine dustEmmission_Kok14(em, soilF, lat,dxdy_degr, inNestNr, ix_wind, iy_w
         
        
         !******************************************************************
-        !Calculate emitted mass (em) per time step if the threshold for saltation is exceeded
+        !Calculate emitted mass (em_mass) per time step if the threshold for saltation is exceeded
         !******************************************************************	
 	if(u_star_local.ge.u_star_t)then	
 		
 		!multiplication factor accounting for time step, area and conversion to kg
 		!**********************************************************
-		mfac=3600.0*time_int*dxdy_degr*111.0e3*&
-				dxdy_degr*cos(pi/180.0*lat)*111.0e3	
+		mfac=3600.0*time_int*gridarea	
 				
 		!Emitted mass in kg when mfac is used (otherwise mass flux in kg m-2 s-1)
                 tmp=C_alpha*(u_star_st-u_star_st_0)/u_star_st_0
-                flux=C_d*f_bare*f_clay*(rho_air*(u_star_local*u_star_local-u_star_t*u_star_t))/u_star_st &
+                flux=scalingFactor*C_d*f_bare*f_clay*(rho_air*(u_star_local*u_star_local-u_star_t*u_star_t))/u_star_st &
                         *((u_star_local/u_star_t)**tmp)
                 mass=flux*mfac
                        
-               em=em+mass
+               em_mass=em_mass+mass
+               em_flux=em_flux+flux*3600.*time_int !kg/m2
                
 	endif
         

--- a/src/dust_mod.f90
+++ b/src/dust_mod.f90
@@ -136,7 +136,7 @@ module dust_mod
     !Model parameters
     !***********************************************************************
     real, parameter             :: mobThreshold = 0.3        !Default mobilization threshold should be wind speed or friction velocity, depending on choice "emissionModel", default should be 0.3 for emissionModel 1
-    real, parameter             :: particlesPerTonDust = 0.8 !Number of particles to be released per ton of dust, adjust with resolution
+    real, parameter             :: particlesPerTonDust = 0.4 !Number of particles to be released per ton of dust, adjust with resolution
     integer, parameter          :: typeSizeDistr=3           !Use size distribution as in DustBowl-Sodemann et al.2015 (1), or similar to Kok 2011 (2 & 3) with many small particles in 3
     integer, parameter          :: Junge_index = 0           !only for typeSizeDistr 1
     real*8, parameter           :: scalingFactor = 4.8e-4    !Default value 4.8e-4 for emissionModel 2

--- a/src/dust_mod.f90
+++ b/src/dust_mod.f90
@@ -147,7 +147,7 @@ module dust_mod
     
     !Switches model
     !***********************************************************************
-    logical, parameter          :: OBSTACLES=.true.          !Influence on roughness length by obstables?
+    logical, parameter          :: OBSTACLES=.false.          !Influence on roughness length by obstables?
     logical, parameter          :: EROSION_TOPO=.true.       !Add erodibility depending on topography acc. to Ginoux et al., 2001?
     logical, parameter          :: PRECIP_BLOCK=.false.      !Block dust emission in case of precipitation?
     logical, parameter          :: SOILMOISTURE_DEP=.true.   !Should threshold friction velocity increase with soil moisture?

--- a/src/subroutinesSoil.f90
+++ b/src/subroutinesSoil.f90
@@ -176,7 +176,7 @@ subroutine getSoilFromLU(soilFraction, landinventory_global, landinventory_n, in
                         !bare land - gravel/rock
                         gridSum = gridSum + 0.4 !Partly erodible, topography to identify rock
 
-                    else if (landinventory_global(i, j) .eq. 10)then
+                    else if ((landinventory_global(i, j) .eq. 10) .or. (landinventory_global(i, j) .eq. 8) .or. (landinventory_global(i, j) .eq. 9) .or. (landinventory_global(i, j) .eq. 11) .or. (landinventory_global(i, j) .eq. 13) ) then
                         !sparse vegetation, get vegetation fraction from ECWMF but due to lower resolution only allow a vegetation cover between 10 and 90%
                         if (useVEG2010)then
                             !Not available in wind field, get from fixed file


### PR DESCRIPTION
- More land cover types used for dust emission
- Use four different sizes of boxes to derive topographic scaling for dust emission.
- Lower An for calculating threshold friction velocity using the scheme developed by Shao and Lu (2000).
- properly implemented KOK14 scheme in FLEXDUST